### PR TITLE
Changing docker image for shiny

### DIFF
--- a/r-shiny/Dockerfile
+++ b/r-shiny/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:latest
+FROM r-base:3.4.1
 
 MAINTAINER Tanmai Gopal "tanmaig@hasura.io"
 


### PR DESCRIPTION
The latest image on r-base seems to be buggy, the version 3.4.1 works perfectly fine. 

Merging this immediately.